### PR TITLE
Append search params instead of overwriting

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
 	"version": "1.0.1",
 	"description": "API wrapper for the Dectalk TTS system",
 	"keywords": [
-		"dectalk",
-		"tts",
 		"api",
 		"text-to-speech",
-		"wav"
+		"tts",
+		"wav",
+		"dectalk"
 	],
 	"homepage": "https://github.com/JstnMcBrd/dectalk-tts",
 	"bugs": "https://github.com/JstnMcBrd/dectalk-tts/issues",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Buffer } from 'node:buffer';
-import { URL, URLSearchParams } from 'node:url';
+import { URL } from 'node:url';
 
 /**
  * @param text The text to send to the aeiou Dectalk API
@@ -16,7 +16,7 @@ export default async function dectalk(text: string): Promise<Buffer> {
 
 	// Format request URL
 	const url = new URL('https://tts.cyzon.us/tts');
-	url.search = new URLSearchParams({ text }).toString();
+	url.searchParams.append('text', text);
 
 	// Send request
 	const response = await fetch(url);


### PR DESCRIPTION
### Changed

- Search params to be appended instead of overwritten
- Package keywords to be sorted based on GitHub's ordering