### PR TITLE
Add more badges to README

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          registry-url: "https://registry.npmjs.org"
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm install

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 [![API status](https://img.shields.io/github/actions/workflow/status/JstnMcBrd/dectalk-tts/api.yml?logo=github&label=API%20status)](https://github.com/JstnMcBrd/dectalk-tts/actions/workflows/api.yml)
 [![Validate](https://img.shields.io/github/actions/workflow/status/JstnMcBrd/dectalk-tts/validate.yml?logo=github&label=Validate)](https://github.com/JstnMcBrd/dectalk-tts/actions/workflows/validate.yml)
+<br />
+[![NPM Version](https://img.shields.io/npm/v/dectalk-tts)](https://www.npmjs.com/package/dectalk-tts)
+[![NPM License](https://img.shields.io/npm/l/dectalk-tts)](./LICENSE)
+![NPM Type Definitions](https://img.shields.io/npm/types/dectalk-tts)
+![NPM Downloads](https://img.shields.io/npm/dt/dectalk-tts)
+<br />
+![Node version](https://img.shields.io/node/v/dectalk-tts)
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dectalk-tts
 
-[![API status](https://github.com/JstnMcBrd/dectalk-tts/actions/workflows/api.yml/badge.svg)](https://github.com/JstnMcBrd/dectalk-tts/actions/workflows/api.yml)
-[![npm package](https://badge.fury.io/js/dectalk-tts.svg)](https://badge.fury.io/js/dectalk-tts)
+[![API status](https://img.shields.io/github/actions/workflow/status/JstnMcBrd/dectalk-tts/api.yml?logo=github&label=API%20status)](https://github.com/JstnMcBrd/dectalk-tts/actions/workflows/api.yml)
+[![Validate](https://img.shields.io/github/actions/workflow/status/JstnMcBrd/dectalk-tts/validate.yml?logo=github&label=Validate)](https://github.com/JstnMcBrd/dectalk-tts/actions/workflows/validate.yml)
 
 ## About
 


### PR DESCRIPTION
### Added

- Badge for Validate workflow status
- Badges for NPM license, type definitions, and downloads
- Badge for required Node version

### Changed

- `API Status` badge to use [shields.io](https://shields.io/)
- `NPM version` badge to use [shields.io](https://shields.io/)

### Fixed

- Double-quote usage in `publish.yml`