### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Please see Chapter 2 of the [Dectalk guide PDF](docs/dtk_reference_guide.pdf) fo
 
 None of these options are hard-coded into this package, so you must format the request string yourself.
 
-(The Dectalk guide PDF was copied from the Dectalk 4.61 release download, which can be found [here](https://theflameofhope.co/dectalkreader1/).)
+(The Dectalk guide PDF was copied from the Dectalk 4.61 release download, which can be found [here](https://web.archive.org/web/20240226085720/https://theflameofhope.co/dectalkreader1/).)
 
 ## Development
 


### PR DESCRIPTION
### Fixed

- Broken Dectalk 4.61 release download link in README