### PR TITLE
Remove reliance on Node libraries for browser compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,26 +44,28 @@ None of the examples below include error handling, but don't forget it!
 
 ```js
 import dectalk from 'dectalk-tts';
+import { Buffer } from 'node:buffer';
 import { writeFileSync } from 'node:fs';
 
 const output = await dectalk('aeiou');
-writeFileSync('output.wav', output);
+writeFileSync('output.wav', Buffer.from(output));
 ```
 
 ### CommonJS
 
 ```js
 const dectalk = require('dectalk-tts');
+const { Buffer } = require('node:buffer');
 const { writeFileSync } = require('node:fs');
 
 (async () => {
 	const output = await dectalk('John Madden');
-	writeFileSync('output.wav', output);
+	writeFileSync('output.wav', Buffer.from(output));
 })();
 
 // or
 
-dectalk('uuuuuuuuuu').then((output) => writeFileSync('output.wav', output));
+dectalk('uuuuuuuuuu').then((output) => writeFileSync('output.wav', Buffer.from(output)));
 ```
 
 ### Options

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## About
 
-**dectalk-tts** is a simple [Node](https://nodejs.org/) package to interact with the **aeiou** Dectalk web API. It is developed in [TypeScript](https://www.typescriptlang.org/) and transpiles to JavaScript (ESM).
+**dectalk-tts** is a simple package to interact with the **aeiou** Dectalk web API. It is developed in [TypeScript](https://www.typescriptlang.org/) and transpiles to JavaScript (ESM).
 
 [Dectalk](https://github.com/dectalk/dectalk) is a text-to-speech engine originally created in the 1980s. Today, it is best known for [viral videos](https://www.youtube.com/watch?v=Hv6RbEOlqRo) of the game [Moonbase Alpha](https://store.steampowered.com/app/39000/Moonbase_Alpha/).
 
@@ -27,9 +27,7 @@
 
 ## Prerequesites
 
-This package has no production dependencies!
-
-However, it does require Node 18 or higher. Use `node --version` to check your node version.
+This package has no production dependencies, and works with Node (`>=18`) or the browser.
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "dectalk-tts",
-	"version": "1.0.2-alpha",
+	"version": "2.0.0-alpha",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "dectalk-tts",
-			"version": "1.0.2-alpha",
+			"version": "2.0.0-alpha",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@jstnmcbrd/eslint-config": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dectalk-tts",
-	"version": "1.0.2-alpha",
+	"version": "2.0.0-alpha",
 	"description": "API wrapper for the Dectalk TTS system",
 	"keywords": [
 		"api",

--- a/src/index.cts
+++ b/src/index.cts
@@ -1,12 +1,10 @@
-import type { Buffer } from 'node:buffer';
-
 /**
  * @param text The text to send to the aeiou Dectalk API
- * @returns A buffer containing wav-encoded binary output
+ * @returns An array buffer containing wav-encoded binary output
  * @throws If `text` is empty or only whitespace
  * @throws If the API returns a non-200 response
  */
-export = async function dectalk(input: string): Promise<Buffer> {
-	const dectalkESM = (await import('./index.js')).default;
-	return await dectalkESM(input);
+export = async function dectalk(input: string): Promise<ArrayBuffer> {
+	const dectalk = (await import('./index.js')).default;
+	return await dectalk(input);
 };

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'node:buffer';
 import { basename } from 'node:path';
 
 import { afterAll, describe, expect, it, vi } from 'vitest';
@@ -35,7 +34,7 @@ describe(basename(import.meta.url), () => {
 	it('should return the buffer if it receives a good response', async () => {
 		fetchMock.mockResolvedValue(goodResponse);
 		const output = await dectalk('test');
-		expect(output).toEqual(Buffer.from(goodResponseBuffer));
+		expect(output).toEqual(goodResponseBuffer);
 	});
 
 	it('should throw an error if it receives a bad response', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,10 @@
-import { Buffer } from 'node:buffer';
-import { URL } from 'node:url';
-
 /**
  * @param text The text to send to the aeiou Dectalk API
- * @returns A buffer containing wav-encoded binary output
+ * @returns An array buffer containing wav-encoded binary output
  * @throws If `text` is empty or only whitespace
  * @throws If the API returns a non-200 response
  */
-export default async function dectalk(text: string): Promise<Buffer> {
+export default async function dectalk(text: string): Promise<ArrayBuffer> {
 	// The API does not like empty prompts
 	text = text.trim();
 	if (text.length === 0) {
@@ -28,6 +25,5 @@ export default async function dectalk(text: string): Promise<Buffer> {
 	}
 
 	// Parse and return response
-	const binaryData = await response.arrayBuffer();
-	return Buffer.from(binaryData);
+	return await response.arrayBuffer();
 }

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import { readFileSync } from 'node:fs';
 import { basename } from 'node:path';
 
@@ -7,7 +8,9 @@ import dectalk from '../src/index.js';
 
 describe(basename(import.meta.url), () => {
 	it('should succeed', async () => {
-		const actual = await dectalk('test');
+		const actual = Buffer.from(
+			await dectalk('test'),
+		);
 		const expected = readFileSync('./test/test.wav');
 		expect(actual).toEqual(expected);
 	});


### PR DESCRIPTION
### Changed

- Return type to `ArrayBuffer` (runtime-agnostic) instead of `Buffer` (Node-specific)
- Documentation to specify the package is browser-compatible
- Package version to `2.0.0-alpha` to reflect breaking changes